### PR TITLE
Do not explicitly specify COS where not needed

### DIFF
--- a/processing-pipelines/image/image-processing-pipeline-gke.md
+++ b/processing-pipelines/image/image-processing-pipeline-gke.md
@@ -50,7 +50,7 @@ gcloud beta container clusters create ${CLUSTER_NAME} \
   --addons=HttpLoadBalancing,HorizontalPodAutoscaling,CloudRun \
   --machine-type=n1-standard-4 \
   --enable-autoscaling --min-nodes=3 --max-nodes=10 \
-  --no-issue-client-certificate --num-nodes=3 --image-type=cos \
+  --no-issue-client-certificate --num-nodes=3 \
   --enable-stackdriver-kubernetes \
   --scopes=cloud-platform,logging-write,monitoring-write,pubsub \
   --zone ${CLUSTER_ZONE} \


### PR DESCRIPTION
Starting with [GKE node version 1.19](https://cloud.google.com/kubernetes-engine/docs/concepts/using-containerd#:~:text=starting%20with%20gke%20node%20version%201.19), COS image type is deprecated. I suggest to not explicitly specify any parameters where defaults would work.