### PR TITLE
Update Java Custom Events sample to use CloudEventsSDK.

### DIFF
--- a/custom-events/client-libraries/java/build.gradle
+++ b/custom-events/client-libraries/java/build.gradle
@@ -5,8 +5,8 @@ plugins {
 
 mainClassName = 'com.google.cloud.eventarc.publishing.example.PublishEventsExample'
 
-group 'org.example'
-version '1.0-SNAPSHOT'
+group 'com.google.cloud.eventarc.samples'
+version '1.0'
 
 repositories {
     mavenCentral()
@@ -16,8 +16,8 @@ repositories {
 dependencies {
     implementation 'com.github.googleapis:java-eventarc-publishing:main-SNAPSHOT'
     implementation group: 'io.cloudevents', name: 'cloudevents-protobuf', version: '2.3.0'
+    implementation group: 'io.cloudevents', name: 'cloudevents-json-jackson', version: '2.3.0'
     implementation group: 'com.google.protobuf', name: 'protobuf-java', version: '3.20.1'
-    implementation 'com.google.code.gson:gson:2.9.0'
 }
 
 test {


### PR DESCRIPTION
This change also shows how to use both TextEvents and Events (proto) with the client libary.

fixes GoogleCloudPlatform/eventarc-samples#103