### PR TITLE
fixes #129: added db-dtypes to requirements.txt

### DIFF
--- a/processing-pipelines/.gcloudignore
+++ b/processing-pipelines/.gcloudignore
@@ -4,7 +4,6 @@
 # obj directories) may be uploaded.
 
 .gcloudignore
-bigquery/
 image/
 bin/
 obj/

--- a/processing-pipelines/Dockerfile
+++ b/processing-pipelines/Dockerfile
@@ -4,10 +4,10 @@ FROM mcr.microsoft.com/dotnet/core/sdk:3.1-alpine AS build
 WORKDIR /app
 
 # Copy local code to the container image.
-COPY bigquery/query-runner ./bigquery/query-runner
+COPY bigquery/query-runner ./bigquery/query-runner/
 
 # Copy common library
-COPY common ./common
+COPY common ./common/
 
 # Install production dependencies
 # Restore as distinct layers

--- a/processing-pipelines/bigquery/README.md
+++ b/processing-pipelines/bigquery/README.md
@@ -108,13 +108,17 @@ docker push gcr.io/$PROJECT_ID/$SERVICE_NAME:v1
 
 Deploy the service while passing in `TO_EMAILS` to email address where you want
 to send the notification and `SENDGRID_API_KEY` with your send SendGrid API Key.
+Optionally, FROM_EMAIL address can passed to overwrite the default FROM email, if 
+required by SendGrid to pass the sender identity verification:
 
 ```sh
 TO_EMAILS=youremail@gmail.com
+# optional, also change the --update-env-vars option below correspondingly
+FROM_EMAIL=my@email.com
 SENDGRID_API_KEY=yoursendgridapikey
 gcloud run deploy $SERVICE_NAME \
   --image gcr.io/$PROJECT_ID/$SERVICE_NAME:v1 \
-  --update-env-vars TO_EMAILS=$TO_EMAILS,SENDGRID_API_KEY=$SENDGRID_API_KEY,BUCKET=$BUCKET \
+  --update-env-vars TO_EMAILS=$TO_EMAILS,SENDGRID_API_KEY=$SENDGRID_API_KEY,BUCKET=$BUCKET,FROM_EMAIL=$FROM_EMAIL \
   --allow-unauthenticated
 ```
 

--- a/processing-pipelines/bigquery/README.md
+++ b/processing-pipelines/bigquery/README.md
@@ -106,9 +106,15 @@ docker build -t gcr.io/$PROJECT_ID/$SERVICE_NAME:v1 .
 docker push gcr.io/$PROJECT_ID/$SERVICE_NAME:v1
 ```
 
+Alternatively, using CloudBuild (with the defaults):
+
+```sh
+gcloud builds submit
+```
+
 Deploy the service while passing in `TO_EMAILS` to email address where you want
 to send the notification and `SENDGRID_API_KEY` with your send SendGrid API Key.
-Optionally, FROM_EMAIL address can passed to overwrite the default FROM email, if 
+Optionally, `FROM_EMAIL` address can passed to overwrite the default FROM email, if 
 required by SendGrid to pass the sender identity verification:
 
 ```sh
@@ -162,6 +168,12 @@ docker build -t gcr.io/$PROJECT_ID/$SERVICE_NAME:v1 .
 docker push gcr.io/$PROJECT_ID/$SERVICE_NAME:v1
 ```
 
+Alternatively, using CloudBuild (with the defaults):
+
+```sh
+gcloud builds submit
+```
+
 Deploy the service while passing in `BUCKET` with the bucket you created earlier.
 
 ```sh
@@ -208,6 +220,12 @@ folder, build and push the container image:
 SERVICE_NAME=query-runner
 docker build -t gcr.io/$PROJECT_ID/$SERVICE_NAME:v1 -f bigquery/$SERVICE_NAME/csharp/Dockerfile .
 docker push gcr.io/$PROJECT_ID/$SERVICE_NAME:v1
+```
+
+Alternatively, using CloudBuild (with the defaults):
+
+```sh
+gcloud builds submit
 ```
 
 Deploy the service while passing in `PROJECT_ID` with your actual project id.

--- a/processing-pipelines/bigquery/chart-creator/python/cloudbuild.yaml
+++ b/processing-pipelines/bigquery/chart-creator/python/cloudbuild.yaml
@@ -1,0 +1,17 @@
+steps:
+- # Build event_handler image
+  name: gcr.io/cloud-builders/docker:latest
+  args: ['build', '--tag=gcr.io/$PROJECT_ID/chart-creator:${_TAG}', '.']
+  id: build
+
+- # Push the container image to Container Registry
+  name: gcr.io/cloud-builders/docker
+  args: ['push', 'gcr.io/$PROJECT_ID/chart-creator:${_TAG}']
+  waitFor: [build]
+  id: push
+
+images: [
+  'gcr.io/$PROJECT_ID/chart-creator:${_TAG}'
+]
+substitutions:
+  _TAG: v1

--- a/processing-pipelines/bigquery/chart-creator/python/requirements.txt
+++ b/processing-pipelines/bigquery/chart-creator/python/requirements.txt
@@ -6,3 +6,4 @@ matplotlib==3.2.2
 cloudevents==1.2.0
 google.cloud.bigquery
 google.cloud.storage
+db-dtypes

--- a/processing-pipelines/bigquery/notifier/python/cloudbuild.yaml
+++ b/processing-pipelines/bigquery/notifier/python/cloudbuild.yaml
@@ -1,0 +1,17 @@
+steps:
+- # Build event_handler image
+  name: gcr.io/cloud-builders/docker:latest
+  args: ['build', '--tag=gcr.io/$PROJECT_ID/notifier:${_TAG}', '.']
+  id: build
+
+- # Push the container image to Container Registry
+  name: gcr.io/cloud-builders/docker
+  args: ['push', 'gcr.io/$PROJECT_ID/notifier:${_TAG}']
+  waitFor: [build]
+  id: push
+
+images: [
+  'gcr.io/$PROJECT_ID/notifier:${_TAG}'
+]
+substitutions:
+  _TAG: v1

--- a/processing-pipelines/cloudbuild.yaml
+++ b/processing-pipelines/cloudbuild.yaml
@@ -1,0 +1,17 @@
+steps:
+- # Build event_handler image
+  name: gcr.io/cloud-builders/docker:latest
+  args: ['build', '--tag=gcr.io/$PROJECT_ID/query-runner:${_TAG}', '.']
+  id: build
+
+- # Push the container image to Container Registry
+  name: gcr.io/cloud-builders/docker
+  args: ['push', 'gcr.io/$PROJECT_ID/query-runner:${_TAG}']
+  waitFor: [build]
+  id: push
+
+images: [
+  'gcr.io/$PROJECT_ID/query-runner:${_TAG}'
+]
+substitutions:
+  _TAG: v1


### PR DESCRIPTION
This PR combines the implementation of the following issues:

#129 : missing db-dtypes dependency in the chart-creator service
#131 : added support for CloudBuild builds
#132 : provides an additional environment variable to configure FROM email address in the notifier service

The corresponding README file was also updated accordingly.