### PR TITLE
 docs: Add web server sample for internal HTTP endpoint targets

### DIFF
--- a/internal-http-endpoints/server.py
+++ b/internal-http-endpoints/server.py
@@ -1,0 +1,59 @@
+# Copyright 2023 Google, LLC.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# [START eventarc_internal_http_endpoint]
+#!/usr/bin/env python3
+from http.server import BaseHTTPRequestHandler, HTTPServer
+import logging
+
+class S(BaseHTTPRequestHandler):
+    def _set_response(self):
+        self.send_response(200)
+        self.send_header('Content-type', 'text/html')
+        self.end_headers()
+
+    def do_GET(self):
+        logging.info("GET request,\nPath: %s\nHeaders:\n%s\n", str(self.path), str(self.headers))
+        self._set_response()
+        self.wfile.write("GET request for {}".format(self.path).encode('utf-8'))
+
+    def do_POST(self):
+        content_length = int(self.headers['Content-Length'])
+        post_data = self.rfile.read(content_length)
+        logging.info("POST request,\nPath: %s\nHeaders:\n%s\n\nBody:\n%s\n",
+                str(self.path), str(self.headers), post_data.decode('utf-8'))
+
+        self._set_response()
+        self.wfile.write("POST request for {}".format(self.path).encode('utf-8'))
+
+def run(server_class=HTTPServer, handler_class=S, port=80):
+    logging.basicConfig(level=logging.INFO)
+    server_address = ('', port)
+    http_server = server_class(server_address, handler_class)
+    logging.info('Starting HTTP Server at port %d...\n', port)
+    try:
+        http_server.serve_forever()
+    except KeyboardInterrupt:
+        pass
+    http_server.server_close()
+    logging.info('Stopping HTTP Server...\n')
+
+if __name__ == '__main__':
+    from sys import argv
+
+    if len(argv) == 2:
+        run(port=int(argv[1]))
+    else:
+        run()
+# [END eventarc_internal_http_endpoint]  


### PR DESCRIPTION
Per b/289404393

Note: temporary sample for Sept 13 preview; waiting on PR in `python-docs-samples`.