### PR TITLE
chore: Migrate gsutil usage to gcloud storage

### DIFF
--- a/processing-pipelines/bigquery/README.md
+++ b/processing-pipelines/bigquery/README.md
@@ -77,9 +77,9 @@ service:
 
 ```sh
 BUCKET=$PROJECT_ID-charts
-gsutil mb -l $REGION gs://$BUCKET
-gsutil uniformbucketlevelaccess set on gs://$BUCKET
-gsutil iam ch allUsers:objectViewer gs://$BUCKET
+gcloud storage buckets create --location=$REGION gs://$BUCKET
+gcloud storage buckets update --uniform-bucket-level-access gs://$BUCKET
+gcloud storage buckets add-iam-policy-binding gs://$BUCKET --member=allUsers --role=objectViewer
 ```
 
 ## Notifier
@@ -325,7 +325,7 @@ gcloud scheduler jobs run cre-scheduler-uk
 After a minute or so, you should see 2 charts in the bucket:
 
 ```sh
-gsutil ls gs://$BUCKET
+gcloud storage ls gs://$BUCKET
 
 gs://events-atamel-charts/chart-cyprus.png
 gs://events-atamel-charts/chart-unitedkingdom.png

--- a/processing-pipelines/bigquery/bigquery-processing-pipeline-eventarc-crfa.md
+++ b/processing-pipelines/bigquery/bigquery-processing-pipeline-eventarc-crfa.md
@@ -155,9 +155,9 @@ trigger location:
 
 ```sh
 BUCKET=$PROJECT_ID-charts-gke
-gsutil mb -l $CLUSTER_LOCATION gs://$BUCKET
-gsutil uniformbucketlevelaccess set on gs://$BUCKET
-gsutil iam ch allUsers:objectViewer gs://$BUCKET
+gcloud storage buckets create gs://$BUCKET --location=$CLUSTER_LOCATION
+gcloud storage buckets update gs://$BUCKET --uniform-bucket-level-access
+gcloud storage buckets add-iam-policy-binding gs://$BUCKET --member=allUsers --role=objectViewer
 ```
 
 ## Notifier
@@ -389,7 +389,7 @@ gcloud scheduler jobs run cre-scheduler-uk
 After a minute or so, you should see 2 charts in the bucket:
 
 ```sh
-gsutil ls gs://$BUCKET
+gcloud storage ls gs://$BUCKET
 
 gs://events-atamel-charts/chart-cyprus.png
 gs://events-atamel-charts/chart-unitedkingdom.png

--- a/processing-pipelines/bigquery/bigquery-processing-pipeline-gke.md
+++ b/processing-pipelines/bigquery/bigquery-processing-pipeline-gke.md
@@ -97,9 +97,9 @@ the charts in the bucket are all public:
 
 ```sh
 export BUCKET="$(gcloud config get-value core/project)-charts-gke"
-gsutil mb gs://${BUCKET}
-gsutil uniformbucketlevelaccess set on gs://${BUCKET}
-gsutil iam ch allUsers:objectViewer gs://${BUCKET}
+gcloud storage buckets create gs://${BUCKET}
+gcloud storage buckets update --uniform-bucket-level-access gs://${BUCKET}
+gcloud storage buckets add-iam-policy-binding gs://${BUCKET} --member=allUsers --role=objectViewer
 ```
 
 ## Setup Cloud Storage for events
@@ -323,7 +323,7 @@ gcloud scheduler jobs run cre-scheduler-714c0b82-c441-42f4-8f99-0e2eac9a5869
 After a minute or so, you should see 2 charts in the bucket:
 
 ```sh
-gsutil ls gs://${BUCKET}
+gcloud storage ls gs://${BUCKET}
 
 gs://events-atamel-charts/chart-cyprus.png
 gs://events-atamel-charts/chart-unitedkingdom.png

--- a/processing-pipelines/image-v1/README.md
+++ b/processing-pipelines/image-v1/README.md
@@ -82,8 +82,8 @@ the bucket is in the same region as your Cloud Run service:
 ```sh
 BUCKET1=$PROJECT_ID-images-input
 BUCKET2=$PROJECT_ID-images-output
-gsutil mb -l $REGION gs://$BUCKET1
-gsutil mb -l $REGION gs://$BUCKET2
+gcloud storage buckets create gs://$BUCKET1 --location=$REGION
+gcloud storage buckets create gs://$BUCKET2 --location=$REGION
 ```
 
 ## Watermark
@@ -294,14 +294,14 @@ trigger-labeler
 You can upload an image to the input storage bucket:
 
 ```sh
-gsutil cp ../pictures/beach.jpg gs://$BUCKET1
+gcloud storage cp ../pictures/beach.jpg gs://$BUCKET1
 ```
 
 After a minute or so, you should see resized, watermarked and labelled image in
 the output bucket:
 
 ```sh
-gsutil ls gs://$BUCKET2
+gcloud storage ls gs://$BUCKET2
 
 gs://events-atamel-images-output/beach-400x400-watermark.jpeg
 gs://events-atamel-images-output/beach-400x400.png

--- a/processing-pipelines/image-v1/image-processing-pipeline-eventarc-crfa.md
+++ b/processing-pipelines/image-v1/image-processing-pipeline-eventarc-crfa.md
@@ -160,8 +160,8 @@ the bucket is in the same region as your Cloud Run service:
 ```sh
 BUCKET1=$PROJECT_ID-images-input-gke
 BUCKET2=$PROJECT_ID-images-output-gke
-gsutil mb -l $CLUSTER_LOCATION gs://$BUCKET1
-gsutil mb -l $CLUSTER_LOCATION gs://$BUCKET2
+gcloud storage buckets create --location $CLUSTER_LOCATION gs://$BUCKET1
+gcloud storage buckets create --location $CLUSTER_LOCATION gs://$BUCKET2
 ```
 
 ## Watermark
@@ -383,14 +383,14 @@ trigger-labeler-gke
 You can upload an image to the input storage bucket:
 
 ```sh
-gsutil cp beach.jpg gs://$BUCKET1
+gcloud storage cp beach.jpg gs://$BUCKET1
 ```
 
 After a minute or so, you should see resized, watermarked and labelled image in
 the output bucket:
 
 ```sh
-gsutil ls gs://$BUCKET2
+gcloud storage ls gs://$BUCKET2
 
 gs://events-atamel-images-output/beach-400x400-watermark.jpeg
 gs://events-atamel-images-output/beach-400x400.png

--- a/processing-pipelines/image-v2/README.md
+++ b/processing-pipelines/image-v2/README.md
@@ -80,7 +80,7 @@ Grant the `pubsub.publisher` role to the Cloud Storage service account. This is
 needed for the Eventarc Cloud Storage trigger:
 
 ```sh
-SERVICE_ACCOUNT="$(gsutil kms serviceaccount -p ${PROJECT_NUMBER})"
+SERVICE_ACCOUNT="$(gcloud storage service-agent --project ${PROJECT_NUMBER})"
 
 gcloud projects add-iam-policy-binding ${PROJECT_NUMBER} \
     --member serviceAccount:${SERVICE_ACCOUNT} \
@@ -103,8 +103,8 @@ Create 2 unique storage buckets to save pre and post processed images.
 ```sh
 BUCKET1=$PROJECT_ID-images-input
 BUCKET2=$PROJECT_ID-images-output
-gsutil mb -l $REGION gs://$BUCKET1
-gsutil mb -l $REGION gs://$BUCKET2
+gcloud storage buckets create gs://$BUCKET1 --location $REGION
+gcloud storage buckets create gs://$BUCKET2 --location $REGION
 ```
 
 ## Watermarker
@@ -329,14 +329,14 @@ gcloud eventarc triggers create $TRIGGER_NAME \
 To test the pipeline, upload an image to the input bucket:
 
 ```sh
-gsutil cp beach.jpg gs://$BUCKET1
+gcloud storage cp beach.jpg gs://$BUCKET1
 ```
 
 After a minute or so, you should see resized, watermarked and labelled image in
 the output bucket:
 
 ```sh
-gsutil ls gs://$BUCKET2
+gcloud storage ls gs://$BUCKET2
 
 gs://events-atamel-images-output/beach-400x400-watermark.jpeg
 gs://events-atamel-images-output/beach-400x400.png

--- a/processing-pipelines/image-v3/README.md
+++ b/processing-pipelines/image-v3/README.md
@@ -42,8 +42,8 @@ REGION=us-central1
 BUCKET1=$PROJECT_ID-images-input
 BUCKET2=$PROJECT_ID-images-output
 
-gsutil mb -l $REGION gs://$BUCKET1
-gsutil mb -l $REGION gs://$BUCKET2
+gcloud storage buckets create --location=$REGION gs://$BUCKET1
+gcloud storage buckets create --location=$REGION gs://$BUCKET2
 ```
 
 ## Deploy filter service
@@ -370,7 +370,7 @@ Grant the `pubsub.publisher` role to the Cloud Storage service account. This is
 needed for the Eventarc Cloud Storage trigger:
 
 ```sh
-STORAGE_SERVICE_ACCOUNT="$(gsutil kms serviceaccount -p $PROJECT_ID)"
+STORAGE_SERVICE_ACCOUNT="$(gcloud storage service-agent --project=$PROJECT_ID)"
 
 gcloud projects add-iam-policy-binding $PROJECT_ID \
     --member serviceAccount:$STORAGE_SERVICE_ACCOUNT \
@@ -398,14 +398,14 @@ gcloud eventarc triggers create $TRIGGER_NAME \
 To test the pipeline, upload an image to the input bucket:
 
 ```sh
-gsutil cp beach.jpg gs://$BUCKET1
+gcloud storage cp beach.jpg gs://$BUCKET1
 ```
 
 After a minute or so, you should see resized, watermarked and labelled image in
 the output bucket:
 
 ```sh
-gsutil ls gs://$BUCKET2
+gcloud storage ls gs://$BUCKET2
 
 gs://events-atamel-images-output/beach-400x400-watermark.jpeg
 gs://events-atamel-images-output/beach-400x400.png


### PR DESCRIPTION
Automated: Migrate {target_path} from gsutil to gcloud storage

This CL is part of the on going effort to migrate from the legacy `gsutil` tool to the new and improved `gcloud storage` command-line interface.
`gcloud storage` is the recommended and modern tool for interacting with Google Cloud Storage, offering better performance, unified authentication, and a more consistent command structure with other `gcloud` components. 🚀

### Automation Details

This change was **generated automatically** by an agent that targets users of `gsutil`.
The transformations applied are based on the  [gsutil to gcloud storage migration guide](http://go/gsutil-gcloud-storage-migration-guide).

### ⚠️ Action Required: Please Review and Test Carefully

While we have based the automation on the migration guide, every use case is unique.
**It is crucial that you thoroughly test these changes in environments appropriate to your use-case before merging.**  
Be aware of potential differences between `gsutil` and `gcloud storage` that could impact your workflows.  
For instance, the structure of command output may have changed, requiring updates to any scripts that parse it. Similarly, command behavior can differ subtly; the `gcloud storage rsync` command has a different file deletion logic than `gsutil rsync`, which could lead to unintended file deletions.  

Our migration guides can help guide you through a list of mappings and some notable differences between the two tools.

Standard presubmit tests are run as part of this CL's workflow. **If you need to target an additional test workflow or require assistance with testing, please let us know.**

Please verify that all your Cloud Storage operations continue to work as expected to avoid any potential disruptions in production.

### Support and Collaboration

The `GCS CLI` team is here to help! If you encounter any issues, have a complex use case that this automated change doesn't cover, or face any other blockers, please don't hesitate to reach out.
We are happy to work with you to test and adjust these changes as needed.

**Contact:** `gcs-cli-hyd@google.com`

We appreciate your partnership in this important migration effort!

#gsutil-migration
