### PR TITLE
Add Eventarc team as code owners for Eventarc samples

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,3 +3,4 @@
 
 # Repo owner
 *           @meteatamel
+*           @googleapis/eventarc-team


### PR DESCRIPTION
Add Eventarc team as code owners for Eventarc samples. This is needed for quick turnaround on Eventarc samples.